### PR TITLE
Update plugin to work with Vanilla 2.5

### DIFF
--- a/BetterNotifications/class.betternotifications.plugin.php
+++ b/BetterNotifications/class.betternotifications.plugin.php
@@ -11,7 +11,7 @@ $PluginInfo['BetterNotifications'] = array(
 	'License' => 'GPL-3.0'
 );
 
-class BetterNotifications extends Gdn_Plugin {
+class BetterNotificationsPlugin extends Gdn_Plugin {
 
 	public function Setup() {
 

--- a/BetterNotifications/class.betternotifications.plugin.php
+++ b/BetterNotifications/class.betternotifications.plugin.php
@@ -120,5 +120,3 @@ class BetterNotificationsPlugin extends Gdn_Plugin {
 	}
 
 }
-
-?>


### PR DESCRIPTION
Vanilla needs plugin class names to end with "Plugin" starting from Vanilla 2.5